### PR TITLE
run build in checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  checks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,3 +13,4 @@ jobs:
       with: { node-version: 12.x }
     - run: npm install
     - run: npm run lint
+    - run: npm run build

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,7 +72,7 @@ import Sponsors from '@/sections/Sponsors.vue';
  */
 export default Vue.extend({
   name: 'App',
-  data: () => ({ 
+  data: () => ({
     recruitment: recruitmentConfig,
     club: clubConfig,
     sponsorship: sponsorshipConfig,


### PR DESCRIPTION
on `master`, https://github.com/ubclaunchpad/new/commit/41ca31cac8b60144bda109d6b89bd05a8353462c failed the new trailing whitespace rule in #42  despite the checks workflow passing with `npm run lint`. 

don't really feel like working out why so I'm adding `npm run build` to the standard PR checks