### PR TITLE
add desktop breakpoints for teams

### DIFF
--- a/src/sections/Teams.vue
+++ b/src/sections/Teams.vue
@@ -1,7 +1,8 @@
 <template>
   <div id="container" class="container is-widescreen">
-    <div class="columns is-vcentered">
-      <div class="pad-32 column is-one-third has-text-centered">
+    <div class="columns is-vcentered is-desktop">
+      <div class="column is-one-third-desktop has-text-centered">
+
         <h2>Our Teams</h2>
         <img src="@/assets/screen.png" width="300px" class="teams-image" />
 
@@ -119,6 +120,7 @@ export default Vue.extend({
 }
 
 .stats {
+  max-width: 100%;
   align-items: start;
 
   .stat-desc {


### PR DESCRIPTION
Break into vertical columns sooner, reduce extra spacing, to prevent awkward overlapping. For #2 

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/23356519/79899001-f83e1880-83c0-11ea-897c-dfbf65ab6417.png">
<img width="876" alt="image" src="https://user-images.githubusercontent.com/23356519/79899045-09872500-83c1-11ea-83c4-756f74388917.png">
