### PR TITLE
use columns instead of tiles for projects for responsiveness

### DIFF
--- a/src/components/TeamProjectCard.vue
+++ b/src/components/TeamProjectCard.vue
@@ -43,7 +43,7 @@ export default Vue.extend({
   width: 320px;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 100%;
+  background-size: cover;
   border-radius: 5px;
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.25);
 }

--- a/src/sections/Projects.vue
+++ b/src/sections/Projects.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="container" class="container is-widescreen">
-    <div>
+    <div class="description">
       <h2>Past Projects</h2>
       <p>
         Generations of students have created projects throughout the years as part of Launch Pad -
@@ -12,16 +12,21 @@
       </p>
     </div>
 
-    <div class="tile project-columns">
-      <div v-for="(col, i) in columns" :key="'column-'+i" class="tile is-vertical project-column">
-        <div ref="projects-project-card"
+    <div class="columns is-multiline is-centered projects">
+      <div
+        v-for="(col, i) in columns"
+        :key="'column-'+i"
+        class="column is-one-quarter-widescreen is-half-desktop project-column">
+        <div
+          ref="projects-project-card"
           v-for="(r, j) in col"
           :key="'row-'+i+'-'+j"
-          class="tile project-container">
-          <TeamProjectCard :team="r" />
+          class="project-container">
+          <TeamProjectCard :team="r" class="margin-sides-auto" />
         </div>
       </div>
     </div>
+
   </div>
 </template>
 
@@ -62,14 +67,16 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-.project-column {
-  display: flex;
-  align-items: center;
-  padding-left: 8px;
-  padding-right: 8px;
+.projects {
+  padding-top: 24px;
 
-  .project-container {
-    margin-bottom: 52px;
+  .project-column {
+    padding-top: 0px;
+    padding-bottom: 0px;
+
+    .project-container {
+      margin-bottom: 32px;
+    }
   }
 }
 </style>

--- a/src/sections/Teams.vue
+++ b/src/sections/Teams.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="container" class="container is-widescreen">
     <div class="columns is-vcentered is-desktop">
-      <div class="column is-one-third-desktop has-text-centered">
+      <div class="column is-two-fifths-desktop has-text-centered">
 
         <h2>Our Teams</h2>
         <img src="@/assets/screen.png" width="300px" class="teams-image" />
@@ -24,18 +24,24 @@
           This year, we had <b>{{ memberCount }} members</b> across <b>{{ teams.length }} teams</b>.
         </p>
       </div>
+
       <div class="column">
-        <div class="tile">
-          <div v-for="(col, i) in columns" :key="'column-'+i" class="tile is-vertical project-column">
-            <div ref="teams-project-card"
+        <div class="columns is-multiline is-centered projects">
+          <div
+            v-for="(col, i) in columns"
+            :key="'column-'+i"
+            class="column is-one-half project-column">
+            <div
+              ref="teams-project-card"
               v-for="(r, j) in col"
               :key="'row-'+i+'-'+j"
-              class="tile project-container">
-              <TeamProjectCard :team="r" />
+              class="project-container">
+              <TeamProjectCard :team="r" class="margin-sides-auto" />
             </div>
           </div>
         </div>
       </div>
+
     </div>
   </div>
 </template>
@@ -106,16 +112,16 @@ export default Vue.extend({
   border-radius: 12px;
 }
 
-.project-column {
-  display: flex;
-  align-items: center;
-  padding-right: 16px;
-  padding-left: 16px;
+.projects {
+  padding-top: 24px;
 
-  .project-container {
-    display: flex;
-    align-items: center;
-    margin-bottom: 36px;
+  .project-column {
+    padding-top: 0px;
+    padding-bottom: 0px;
+
+    .project-container {
+      margin-bottom: 32px;
+    }
   }
 }
 

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -30,6 +30,14 @@
       margin-top: 24px;
     }
   }
+
+  &-sides {
+    // essentially horizontal centers on block elements
+    &-auto {
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
 }
 
 .columns {


### PR DESCRIPTION
for #2 

replaces `tile` with `column` for better control over how things reflow. we no longer have projects disappearing off the screen!

![responsive-demo](https://user-images.githubusercontent.com/23356519/80128609-c5c02700-854a-11ea-901d-2c4ea9c9ab2a.gif)

on my favourite iphone:

<img width="369" alt="image" src="https://user-images.githubusercontent.com/23356519/80128846-1afc3880-854b-11ea-878f-6c969ddda205.png">

