### PR TITLE
keep project cards, sponsor logos hidden before animate

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -73,14 +73,14 @@ type VueRef = Vue | Element | Vue[] | Element[];
  *       },
  *     },
  *     created() {
+ *       this.handleScroll();
  *       window.addEventListener('scroll', this.handleScroll);
  *     },
  *     // ...
  * 
  * For elements animating elements that might load a bit slower, such as the elements including
  * images, it might be useful to mark them as `.hidden` beforehand and removing the classes on
- * scroll by using `removeClasses: 'hidden'`. In those cases, you'll want to `handleScroll` explicitly
- * as part of `created()`.
+ * scroll by using `removeClasses: 'hidden'`.
  * 
  * @param w window instance
  * @param ref element to check and update, retrieved from `this.$refs`
@@ -92,14 +92,12 @@ export function updateClassesIfInView(w: Window, ref: VueRef, options: {
   removeClasses?: string;
 }) {
   if (ref instanceof Element && isInView(w, ref)) {
-    console.log('ref in view', ref);
     if (options.addClasses) updateClasses(ref, options.addClasses, false);
     if (options.removeClasses) updateClasses(ref, options.removeClasses, true);
   } else if (ref instanceof Array) {
     ref.forEach((r: Vue | Element) => {
       if (r instanceof Element) {
         if (isInView(w, r)) {
-          console.log('refs in view', ref);
           if (options.addClasses) updateClasses(r, options.addClasses, false);
           if (options.removeClasses) updateClasses(r, options.removeClasses, true);
         }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -54,46 +54,70 @@ function isInView(w: Window, el: Element): boolean {
 
 function updateClasses(el: Element, classNames: string, remove: boolean) {
   const classes = classNames.split(' ');
-  if (!remove) classes.forEach((c) => el.classList.add(c));
-  else classes.forEach((c) => el.classList.remove(c));
+  if (!remove) el.classList.add(...classes);
+  else el.classList.remove(...classes);
 }
 
 type VueRef = Vue | Element | Vue[] | Element[];
 
 /**
- * Check if given element is within the window bounds (aka "in view") and attach classnames to it
- * if it is. Useful for making animations.
+ * Check if given element is within the window bounds (aka "in view") and updates classnames to it
+ * if it is. Useful for making animations:
+ * 
+ *     // ...
+ *     methods: {
+ *       handleScroll() {
+ *         updateClassesIfInView(window, this.$refs['position-animated'], {
+ *           addClasses: 'animated fadeInLeft',
+ *         });
+ *       },
+ *     },
+ *     created() {
+ *       window.addEventListener('scroll', this.handleScroll);
+ *     },
+ *     // ...
+ * 
+ * For elements animating elements that might load a bit slower, such as the elements including
+ * images, it might be useful to mark them as `.hidden` beforehand and removing the classes on
+ * scroll by using `removeClasses: 'hidden'`. In those cases, you'll want to `handleScroll` explicitly
+ * as part of `created()`.
  * 
  * @param w window instance
  * @param ref element to check and update, retrieved from `this.$refs`
  * @param classNames string of classnames (e.g. 'animated fadeInleft')
  * @param removeIfNot optionally indicate that classes should be removed if the element has left the view
  */
-export function attachClassesIfInView(w: Window, ref: VueRef, classNames: string, removeIfNot?: boolean) {
-  if (ref instanceof Element) {
-    if (isInView(w, ref)) updateClasses(ref, classNames, false);
-    else if (removeIfNot) updateClasses(ref, classNames, true);
+export function updateClassesIfInView(w: Window, ref: VueRef, options: {
+  addClasses?: string;
+  removeClasses?: string;
+}) {
+  if (ref instanceof Element && isInView(w, ref)) {
+    console.log('ref in view', ref);
+    if (options.addClasses) updateClasses(ref, options.addClasses, false);
+    if (options.removeClasses) updateClasses(ref, options.removeClasses, true);
   } else if (ref instanceof Array) {
     ref.forEach((r: Vue | Element) => {
       if (r instanceof Element) {
-        if (isInView(w, r)) updateClasses(r, classNames, false);
-        else if (removeIfNot) updateClasses(r, classNames, true);
+        if (isInView(w, r)) {
+          console.log('refs in view', ref);
+          if (options.addClasses) updateClasses(r, options.addClasses, false);
+          if (options.removeClasses) updateClasses(r, options.removeClasses, true);
+        }
       }
     });
   }
 }
 
-
 /**
  * Describes the state of a modal
  */
 export interface ModalState {
-/**
- * if the modal is open or closed
- */
+  /**
+   * if the modal is open or closed
+   */
   isActive: boolean;
-/**
- * The name of the selected team 
- */
+  /**
+   * The name of the selected team 
+   */
   activeTeamName: string;
 }

--- a/src/sections/About.vue
+++ b/src/sections/About.vue
@@ -54,6 +54,7 @@ export default Vue.extend({
     },
   },
   created() {
+    this.handleScroll();
     window.addEventListener('scroll', this.handleScroll);
   },
   components: {

--- a/src/sections/About.vue
+++ b/src/sections/About.vue
@@ -31,7 +31,7 @@
 import Vue from 'vue';
 import ClubSocialsLinks from '@/components/links/ClubSocialsLinks.vue';
 import { ClubSocials } from '@/data/types';
-import { attachClassesIfInView } from '@/lib/util';
+import { updateClassesIfInView } from '@/lib/util';
 
 /**
  * About implements a section for introducing visitors to Launch Pad.
@@ -45,8 +45,12 @@ export default Vue.extend({
   },
   methods: {
     handleScroll() {
-      attachClassesIfInView(window, this.$refs['about-col-left'], 'animated fadeInLeft');
-      attachClassesIfInView(window, this.$refs['about-col-right'], 'animated fadeInLeft');
+      updateClassesIfInView(window, this.$refs['about-col-left'], {
+        addClasses: 'animated fadeInLeft',
+      });
+      updateClassesIfInView(window, this.$refs['about-col-right'], {
+        addClasses: 'animated fadeInLeft',
+      });
     },
   },
   created() {

--- a/src/sections/Join.vue
+++ b/src/sections/Join.vue
@@ -52,6 +52,7 @@ export default Vue.extend({
     },
   },
   created() {
+    this.handleScroll();
     window.addEventListener('scroll', this.handleScroll);
   },
 });

--- a/src/sections/Join.vue
+++ b/src/sections/Join.vue
@@ -31,7 +31,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { ClubPosition } from '@/data/types';
-import { attachClassesIfInView } from '@/lib/util';
+import { updateClassesIfInView } from '@/lib/util';
 
 /**
  * Join implements a section for encouraging users to apply to Launch Pad. It should only be
@@ -46,7 +46,9 @@ export default Vue.extend({
   },
   methods: {
     handleScroll() {
-      attachClassesIfInView(window, this.$refs['position-animated'], 'animated fadeInLeft');
+      updateClassesIfInView(window, this.$refs['position-animated'], {
+        addClasses: 'animated fadeInLeft',
+      });
     },
   },
   created() {

--- a/src/sections/Projects.vue
+++ b/src/sections/Projects.vue
@@ -23,7 +23,7 @@
           ref="projects-project-card"
           v-for="(r, j) in col"
           :key="'row-'+i+'-'+j"
-          class="project-container">
+          class="project-container hidden">
           <TeamProjectCard @projectClicked="setModalState" :team="r" class="margin-sides-auto" />
         </div>
       </div>
@@ -35,7 +35,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Team } from '@/data/types';
-import { generateColumns, attachClassesIfInView, ModalState} from '@/lib/util';
+import { generateColumns, updateClassesIfInView, ModalState} from '@/lib/util';
 import TeamProjectCard from '@/components/TeamProjectCard.vue';
 import TeamProjectModal from '@/components/TeamProjectModal.vue';
 
@@ -58,7 +58,10 @@ export default Vue.extend({
   data: () => ({isActive: false, activeTeamName: '0'}),
   methods: {
     handleScroll() {
-      attachClassesIfInView(window, this.$refs['projects-project-card'], 'animated fadeInUp slow');
+      updateClassesIfInView(window, this.$refs['projects-project-card'], {
+        addClasses: 'animated fadeInUp slow',
+        removeClasses: 'hidden',
+      });
     },
     setModalState(state: ModalState){
       this.isActive = state.isActive;
@@ -72,6 +75,7 @@ export default Vue.extend({
     },
   },
   created() {
+    this.handleScroll();
     window.addEventListener('scroll', this.handleScroll);
   },
   components: {

--- a/src/sections/Sponsors.vue
+++ b/src/sections/Sponsors.vue
@@ -8,17 +8,17 @@
         <div v-for="(col, i) in columns" :key="'column-'+i" class="tile is-vertical sponsor-column">
             <a v-for="(s, j) in col" :key="'row-'+i+'-'+j" :href="s.website" class="tile sponsor-container" target="_blank">
               <img ref="sponsor-logo"
+                class="sponsor-img hidden"
                 :src="s.logoURL"
                 :alt="s.name"
                 :style="{
                   filter: s.logoFilter,
-                  'object-fit': 'contain'
                 }" />
             </a>
         </div>
       </div>
 
-      <p class="package-link-p" ref="sponsor-cta">
+      <p ref="sponsor-pkg" class="package-link-p">
         <a :href="sponsorshipPackage" target="_blank" class="package-link">
           <b>Interested in sponsoring us? View our sponsorship package here ></b>
         </a>
@@ -30,7 +30,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { ClubSponsor } from '@/data/types';
-import { generateColumns, attachClassesIfInView } from '@/lib/util';
+import { generateColumns, updateClassesIfInView } from '@/lib/util';
 
 /**
  * Sponsors implements a section to feature Launch Pad's sponsors.
@@ -52,11 +52,18 @@ export default Vue.extend({
   },
   methods: {
     handleScroll() {
-      attachClassesIfInView(window, this.$refs['sponsor-logo'], 'animated fadeInUp');
-      attachClassesIfInView(window, this.$refs['sponsor-cta'], 'animated fadeInUp delay-1s');
+      console.log(this.$refs['sponsor-logo']);
+      updateClassesIfInView(window, this.$refs['sponsor-logo'], {
+        addClasses: 'animated fadeInUp',
+        removeClasses: 'hidden',
+      });
+      updateClassesIfInView(window, this.$refs['sponsor-pkg'], {
+        addClasses: 'animated fadeInUp',
+      });
     },
   },
   created() {
+    this.handleScroll();
     window.addEventListener('scroll', this.handleScroll);
   },
 });
@@ -77,12 +84,16 @@ h2 {
     max-width: 320px;
     max-height: 300px;
     margin: 32px;
-    object-fit: contain;
+
+    .sponsor-img {
+      object-fit: contain;
+    }
   }
 }
 
 .package-link-p {
   margin-top: 32px;
+  animation-delay: 0.5s;
 
   .package-link {
     margin-top: 62px;

--- a/src/sections/Sponsors.vue
+++ b/src/sections/Sponsors.vue
@@ -52,7 +52,6 @@ export default Vue.extend({
   },
   methods: {
     handleScroll() {
-      console.log(this.$refs['sponsor-logo']);
       updateClassesIfInView(window, this.$refs['sponsor-logo'], {
         addClasses: 'animated fadeInUp',
         removeClasses: 'hidden',

--- a/src/sections/Teams.vue
+++ b/src/sections/Teams.vue
@@ -37,7 +37,7 @@
               ref="teams-project-card"
               v-for="(r, j) in col"
               :key="'row-'+i+'-'+j"
-              class="tile project-container">
+              class="project-container hidden">
               <TeamProjectCard @projectClicked="setModalState" :team="r" class="margin-sides-auto"/>
             </div>
           </div>
@@ -51,7 +51,8 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Team } from '@/data/types';
-import { generateColumns, attachClassesIfInView, ModalState } from '@/lib/util';
+import { generateColumns, updateClassesIfInView, ModalState } from '@/lib/util';
+
 import TeamProjectCard from '@/components/TeamProjectCard.vue';
 import TeamProjectModal from '@/components/TeamProjectModal.vue';
 
@@ -96,7 +97,10 @@ export default Vue.extend({
   },
   methods: {
     handleScroll() {
-      attachClassesIfInView(window, this.$refs['teams-project-card'], 'animated fadeInRight slow');
+      updateClassesIfInView(window, this.$refs['teams-project-card'], {
+        addClasses: 'animated fadeInRight slow',
+        removeClasses: 'hidden',
+      });
     },
     setModalState(state: ModalState){
       this.isActive = state.isActive;
@@ -110,6 +114,7 @@ export default Vue.extend({
     },
   },
   created() {
+    this.handleScroll();
     window.addEventListener('scroll', this.handleScroll);
   },
   components: {

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -49,3 +49,9 @@
     }
   }
 }
+
+// use opacity instead of display:none for hiding to avoid messing with element positioning, so that
+// using this class alongside [[`updateClassesIfInView`]] doesn't break.
+.hidden {
+  opacity: 0;
+}


### PR DESCRIPTION
closes #58 

This changes updates the behaviour of the project cards and sponsor logos' animate-on-load by giving them 0 opacity before the onscroll hits them.

Also slightly reduced the delay before the sponsorship CTA pops up.