### PR TITLE
forcibly override default unicon fill

### DIFF
--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -71,7 +71,7 @@
 
 // see unicons.ts
 .unicon {
-  fill: $white;
+  fill: $white !important;
   margin: 8px;
 
   &.icon {
@@ -106,6 +106,6 @@
   }
 
   &.accent {
-    fill: $accent;
+    fill: $accent !important;
   }
 }


### PR DESCRIPTION
follow-up to #80 

for whatever reason, serving via `npm run serve` works fine but the production build deployed doesn't override the unicon fill:

<img width="301" alt="image" src="https://user-images.githubusercontent.com/23356519/80259685-09925980-863b-11ea-9b27-cfde1c4a0ec1.png">

This seems to fix it:

```
NODE_ENV=development npm run build
serve ./dist
```

Testing before and after the change indicates that this seems to have the desired effect