### PR TITLE
improve project modal on mobile

### DIFF
--- a/src/components/TeamProjectModal.vue
+++ b/src/components/TeamProjectModal.vue
@@ -111,6 +111,12 @@ export default Vue.extend({
     margin-left: 8px;
   }
 
+  h2 {
+    @media (max-width: $tablet) {
+      font-size: 24px;
+    }
+  }
+
   h3 {
     margin-top: -16px;
     margin-bottom: 24px;

--- a/src/components/TeamProjectModal.vue
+++ b/src/components/TeamProjectModal.vue
@@ -8,10 +8,6 @@
     <div class="modal-background animated fadeIn faster" v-on:click="handleModalClose()"></div>
 
     <div class="modal-content box-shadow animated zoomIn faster">
-      <div class="modal-bg-container">
-        <img class="modal-bg" src="@/assets/backdrop-first.svg" />
-      </div>
-
       <unicon name="times" fill="white" class="close-button icon-small" v-on:click="handleModalClose()"></unicon>
 
       <div class="pad-sides-8 has-text-centered">
@@ -106,14 +102,6 @@ export default Vue.extend({
 
   * {
     position: relative;
-  }
-
-  .modal-bg-container {
-    position: absolute;
-    .modal-bg {
-      overflow: hidden;
-      mix-blend-mode: overlay;
-    }
   }
 
   .close-button {

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,10 +260,10 @@ export const clubConfig: {
       name: 'Brussel Sprouts',
       project: {
         name: 'Rocket 2',
-        description: '🚀 Slack bot, team management, and onboarding system for UBC Launch Pad',
+        description: '🚀 Slack bot for UBC Launch Pad',
         elevatorPitch: `Rocket 2 is a from-the-ground-up rebuild of our previous in-house management
-          Slack bot. Rocket 2 handles team formation, GitHub permissions, and more through a diverse
-          set of commands accessible from Slack.`,
+          Slack bot. Rocket 2 handles team management, GitHub permissions, member onboarding, and
+          more through a robust set of commands accessible from Slack.`,
         banner: {
           url: 'https://raw.githubusercontent.com/ubclaunchpad/rocket2/master/docs/rocket-banner.gif',
         },


### PR DESCRIPTION
closes #90 

* removed the overlay background - with the new content (elevator pitch, media, etc.), I think the card is sufficiently noisy that we no longer need to overlay, and it wasnt working correctly on mobile (and after a good amount of debugging still couldnt figure out so...) - sorry @srijonsaha 
* made title text of project modal smaller on mobile