### PR TITLE
add feedback, netlify to footer

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,19 +1,30 @@
 <template>
   <footer class="footer">
-    <div class="level">
-      <div class="level-left">
-        <p class="level-item">UBC Launch Pad {{ year }}</p>
+    <div class="columns is-vcentered is-desktop">
+      <div class="column has-text-centered-touch">
+        <p class="footer-item">UBC Launch Pad {{ year }}</p>
       </div>
 
-      <div class="level-item">
+      <div class="footer-item column has-text-centered">
         <ClubSocialsLinks :links="socials" class="socials" />
       </div>
 
-      <div class="level-right">
-        <p class="level-item">
+      <div class="footer-item column has-text-centered-touch has-text-right-desktop">
+        <p>
           <a :href="'mailto:' + socials.email">{{ socials.email }}</a>
         </p>
       </div>
+    </div>
+
+    <div class="has-text-centered">
+      <p class="tertiary">
+        See any problems, or have some feedback?
+        <a href="https://github.com/ubclaunchpad/ubclaunchpad.com/issues/new" target="_blank">Let us know!</a>
+      </p>
+
+      <p class="tertiary">
+        This site is powered by <a href="https://www.netlify.com" target="_blank">Netlify</a>.
+      </p>
     </div>
   </footer>
 </template>
@@ -49,8 +60,12 @@ export default Vue.extend({
     padding-right: 0px;
   }
 
+  .footer-item {
+    margin-bottom: 0px;
+  }
+
   .socials {
-    margin-bottom: 16px;
+    margin-bottom: 0px;
   }
 }
 </style>

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -24,6 +24,13 @@ p {
     opacity: 1;
   }
 
+  &.tertiary {
+    color: $grey;
+    opacity: 0.8;
+    font-size: 16px;
+    margin-bottom: 16px;
+  }
+
   a {
     color: $white
   }


### PR DESCRIPTION
Adds feedback link to footer (closes #107), and adds a Netlify link in the bottom (I'm going to try and apply for their open source plan: https://www.netlify.com/legal/open-source-policy/)

Also fixes alignment of footer by getting rid of `level`

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/23356519/80320815-7d646b80-87cd-11ea-8026-c2a34872b3dd.png">

<img width="472" alt="image" src="https://user-images.githubusercontent.com/23356519/80320805-750c3080-87cd-11ea-859f-f2cd8ea3b181.png">

