### PR TITLE
correctly query for project by linkedProject

### DIFF
--- a/src/sections/Projects.vue
+++ b/src/sections/Projects.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
 
     // jump to linked project if one is provided
     const linkedProject = getURLParams(window.location).get('project');
-    if (linkedProject && getTeamByName(this.teams, this.activeTeamName)) {
+    if (linkedProject && getTeamByName(this.teams, linkedProject)) {
       this.$gtag.event('direct-project-link', {
         event_category: 'projects',
         event_label: linkedProject,


### PR DESCRIPTION
closes #123 

example of bug caused by code duplication - see #117 :(