### PR TITLE
add meta tags for OpenGraph

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,15 @@
     <!-- Lato regular, regular italic -->
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital@0;1&display=swap" rel="stylesheet"> 
 
+    <!-- standard metadata -->
     <title>UBC Launch Pad</title>
+    <meta name="description" content="A student-run software engineering club based in the University of British Columbia">
+
+    <!-- Open Graph: https://ogp.me/ -->
+    <meta property="og:title" content="UBC Launch Pad">
+    <meta property="og:url" content="https://ubclaunchpad.com">
+    <meta property="og:image" content="https://raw.githubusercontent.com/ubclaunchpad/ubclaunchpad.com/master/.static/banner.png">
+    <meta property="og:description" content="A student-run software engineering club based in the University of British Columbia">
   </head>
   <body>
     <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,6 @@
     <!-- Open Graph: https://ogp.me/ -->
     <meta property="og:title" content="UBC Launch Pad">
     <meta property="og:url" content="https://ubclaunchpad.com">
-    <meta property="og:image" content="https://raw.githubusercontent.com/ubclaunchpad/ubclaunchpad.com/master/.static/banner.png">
     <meta property="og:description" content="A student-run software engineering club based in the University of British Columbia">
   </head>
   <body>


### PR DESCRIPTION
Adds a `description` meta tag as well as `title`, `url`, `description` for [OpenGraph](https://ogp.me)

Thought about adding an `og:image`, but decided against it for now - this should be a proper image designed for sharing, not something like our banner image - opened #126 for that