### PR TITLE
generate file documenting current website redirects

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -46,7 +46,7 @@ When preparing an event, you might want to be able to share `https://ubclaunchpa
 }
 ```
 
-Also refer to [USING.md](https://github.com/ubclaunchpad/ubclaunchpad.com/blob/master/USING.md#redirect-links) for more details.
+Also refer to [USING.md](https://github.com/ubclaunchpad/ubclaunchpad.com/blob/master/USING.md#redirect-links) for more details. You can also check [`redirects.txt`](https://ubclaunchpad.com/redirects.txt) for a full list of currently active redirects.
 
 <br />
 

--- a/USING.md
+++ b/USING.md
@@ -22,10 +22,11 @@ https://ubclaunchpad.com#projects
 The website automatically generates useful redirects such as:
 
 ```
-https://ubclaunchpad.com/facebook -> https://www.facebook.com/ubclaunchpad
-https://ubclaunchpad.com/medium   -> https://medium.com/ubc-launch-pad-software-engineering-blog
+https://ubclaunchpad.com/sponsorship -> redirects to current sponsorship package
+https://ubclaunchpad.com/facebook    -> redirects to https://www.facebook.com/ubclaunchpad
+https://ubclaunchpad.com/medium      -> redirects to https://medium.com/ubc-launch-pad-software-engineering-blog
 ```
 
-See [`tools/generateRedirects.ts`](./tools/generateRedirects.ts) for a full list of redirects. You can also add custom redirects - see the [Website Configuration Guide](https://ubclaunchpad.com/config) for more details.
+See [`redirects.txt`](https://ubclaunchpad.com/redirects.txt) for a full list of currently active redirects. You can also add additional custom redirects as needed - see the [Website Configuration Guide](https://ubclaunchpad.com/config) for more details!
 
 <br />

--- a/tools/generateRedirects.ts
+++ b/tools/generateRedirects.ts
@@ -36,12 +36,15 @@ redirectsConfig.forEach((r) => {
 // write to Netlify `_redirects`, as well as a `redirects.txt` that we can access
 console.log('generated redirects', redirects);
 writeFileSync('./dist/_redirects', redirects.join('\n'));
-writeFileSync('./dist/redirects.txt', `# redirects.txt
+writeFileSync('./dist/redirects.txt', `#
+# redirects.txt
 #
 # This file lists all currently active redirects for https://ubclaunchpad.com - on the left of each
 # row is the path that gets redirected, and on the right is the destination.
 #
-# For example, 'https://ubclaunchpad.com/facebook' will redirect to '${clubConfig.socials.facebook}'.
+# For example, the first entry indicates that 'https://ubclaunchpad.com/facebook' will redirect to
+# '${clubConfig.socials.facebook}'.
+#
 
 ${redirects.join('\n')}
 `);

--- a/tools/generateRedirects.ts
+++ b/tools/generateRedirects.ts
@@ -33,7 +33,7 @@ redirectsConfig.forEach((r) => {
   redirects.push(`${r.path}\t${r.target}`);
 });
 
-// write to Netlify `_redirects`, as well as a more accesssible `redirects.txt` that we can access
+// write to Netlify `_redirects`, as well as a `redirects.txt` that we can access
 console.log('generated redirects', redirects);
 writeFileSync('./dist/_redirects', redirects.join('\n'));
 writeFileSync('./dist/redirects.txt', redirects.join('\n'));

--- a/tools/generateRedirects.ts
+++ b/tools/generateRedirects.ts
@@ -36,4 +36,9 @@ redirectsConfig.forEach((r) => {
 // write to Netlify `_redirects`, as well as a `redirects.txt` that we can access
 console.log('generated redirects', redirects);
 writeFileSync('./dist/_redirects', redirects.join('\n'));
-writeFileSync('./dist/redirects.txt', redirects.join('\n'));
+writeFileSync('./dist/redirects.txt',
+  `# This file lists all currently active redirects for https://ubclaunchpad.com - on the left is the\n
+  # path that gets redirected, and on the right is the destination (for example,
+  # 'https://ubclaunchpad.com/facebook'\n redirects to '${clubConfig.socials.facebook}'
+  \n\n
+  ${redirects.join('\n')}`);

--- a/tools/generateRedirects.ts
+++ b/tools/generateRedirects.ts
@@ -36,9 +36,12 @@ redirectsConfig.forEach((r) => {
 // write to Netlify `_redirects`, as well as a `redirects.txt` that we can access
 console.log('generated redirects', redirects);
 writeFileSync('./dist/_redirects', redirects.join('\n'));
-writeFileSync('./dist/redirects.txt',
-  `# This file lists all currently active redirects for https://ubclaunchpad.com - on the left is the\n
-  # path that gets redirected, and on the right is the destination (for example,
-  # 'https://ubclaunchpad.com/facebook'\n redirects to '${clubConfig.socials.facebook}'
-  \n\n
-  ${redirects.join('\n')}`);
+writeFileSync('./dist/redirects.txt', `# redirects.txt
+#
+# This file lists all currently active redirects for https://ubclaunchpad.com - on the left of each
+# row is the path that gets redirected, and on the right is the destination.
+#
+# For example, 'https://ubclaunchpad.com/facebook' will redirect to '${clubConfig.socials.facebook}'.
+
+${redirects.join('\n')}
+`);

--- a/tools/generateRedirects.ts
+++ b/tools/generateRedirects.ts
@@ -33,6 +33,7 @@ redirectsConfig.forEach((r) => {
   redirects.push(`${r.path}\t${r.target}`);
 });
 
-// write to output
+// write to Netlify `_redirects`, as well as a more accesssible `redirects.txt` that we can access
 console.log('generated redirects', redirects);
 writeFileSync('./dist/_redirects', redirects.join('\n'));
+writeFileSync('./dist/redirects.txt', redirects.join('\n'));


### PR DESCRIPTION
follow-up to #121 

Since our redirects are generated, and the `_redirects` file is not accessible, generate an additional `redirects.txt` that can be used to see what redirects are active at the moment.