### PR TITLE
fix sponsors section ID

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,8 @@
         :positions="recruitment.positions" />
     </Section>
 
-    <Section :section-id="6" size="medium">
+    <!-- section-id depends on if join section exists or not -->
+    <Section :section-id="recruitment.applicationsOpen ? 6 : 5" size="medium">
       <Sponsors
         :sponsors="sponsorship.sponsors"
         :sponsorship-package="sponsorship.packageURL" />


### PR DESCRIPTION
sponsors now correctly gets a background - before:

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/23356519/80423908-9b959e80-8895-11ea-955f-4fd139ae5dc2.png">

after:

<img width="1632" alt="image" src="https://user-images.githubusercontent.com/23356519/80423876-8de01900-8895-11ea-868e-af617c8355bd.png">
