### PR TITLE
align rocket to text on mobile

### DIFF
--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -70,11 +70,12 @@ export default Vue.extend({
 
     .rocket {
       max-height: none;
-      width: auto;
       height: 55px;
       @media(max-width: $touch) {
-        margin-top: 32px;
         height: 96px;
+        margin-top: 32px;
+        margin-left: -18px; // align rocket to left
+        object-fit: cover;
       }
     }
   }


### PR DESCRIPTION
this was caused by #136 , which I needed to allow the rocket to be used as a logo elswhere - but it ended up making the alignment a bit weird

closes #157 

<img width="398" alt="image" src="https://user-images.githubusercontent.com/23356519/80872990-57761580-8c6a-11ea-9e4a-af7679244759.png">
