### PR TITLE
point to og:image with full url, add twitter meta

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
     <meta property="og:image" content="https://ubclaunchpad.com/share.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="628">
+    <!-- ask twitter to show the full image so that we don't get cropped into a square-->
+    <meta name="twitter:card" content="summary_large_image">
   </head>
   <body>
     <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     <meta property="og:description" content="Launch Pad is student-run software engineering club based in the University of British Columbia.">
     <meta property="og:type" content="website">
     <!-- note: "Images are cached based on the URL and won't be updated unless the URL changes" -->
-    <meta property="og:image" content="/share.jpg">
+    <meta property="og:image" content="https://ubclaunchpad.com/share.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="628">
   </head>


### PR DESCRIPTION
I couldnt figure out why the image wasnt showing up, then [I realized `og:image` must be a full URL](https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url) 🤦‍♂️

checking with https://metatags.io/:

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/23356519/80996797-43125400-8df5-11ea-8f9a-8bfd6b24bbed.png">

let's hope this works 🙏
