### PR TITLE
add /latest path to redirects config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -461,4 +461,9 @@ export const redirectsConfig: Redirect[] = [
     path: '/newsletter',
     target: '/#resources',
   },
+  {
+    // redirect to latest campaign's Medium blog post
+    path: '/latest',
+    target: `${clubConfig.socials.medium}/state-of-launch-pad-2020-2da3f4cfbc36`,
+  },
 ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -462,7 +462,8 @@ export const redirectsConfig: Redirect[] = [
     target: '/#resources',
   },
   {
-    // redirect to latest campaign's Medium blog post
+    // redirect to latest campaign's Medium blog post - learn more about campaigns in our handbook:
+    // https://docs.ubclaunchpad.com/handbook/tools/social-media#social-media-campaigns
     path: '/latest',
     target: `${clubConfig.socials.medium}/state-of-launch-pad-2020-2da3f4cfbc36`,
   },


### PR DESCRIPTION
Closes #190 

Just added the `/latest` path which should be used to handle redirects to the current social media campaign's Medium blog post.